### PR TITLE
Fixed InitialFolder + fix bug crash for SaveFileDialog when using root directory

### DIFF
--- a/src/Ookii.Dialogs.Wpf/VistaFileDialog.cs
+++ b/src/Ookii.Dialogs.Wpf/VistaFileDialog.cs
@@ -608,17 +608,13 @@ namespace Ookii.Dialogs.Wpf
             // Set the default file name
             if( !(_fileNames == null || _fileNames.Length == 0 || string.IsNullOrEmpty(_fileNames[0])) )
             {
-                string parent = Path.GetDirectoryName(_fileNames[0]);
-                if( parent == null || !Directory.Exists(parent) )
-                {
-                    dialog.SetFileName(_fileNames[0]);
-                }
-                else
-                {
-                    string folder = Path.GetFileName(_fileNames[0]);
-                    dialog.SetFolder(NativeMethods.CreateItemFromParsingName(parent));
-                    dialog.SetFileName(folder);
-                }
+                dialog.SetFileName(_fileNames[0]);
+            }
+
+            // Set the default directory
+            if( Directory.Exists(_initialDirectory) )
+            {
+                dialog.SetFolder(NativeMethods.CreateItemFromParsingName(_initialDirectory));
             }
 
             // Set the filter
@@ -641,13 +637,6 @@ namespace Ookii.Dialogs.Wpf
             if( _addExtension && !string.IsNullOrEmpty(_defaultExt) )
             {
                 dialog.SetDefaultExtension(_defaultExt);
-            }
-
-            // Initial directory
-            if( !string.IsNullOrEmpty(_initialDirectory) )
-            {
-                Ookii.Dialogs.Wpf.Interop.IShellItem item = NativeMethods.CreateItemFromParsingName(_initialDirectory);
-                dialog.SetDefaultFolder(item);
             }
 
             if( !string.IsNullOrEmpty(_title) )

--- a/src/Ookii.Dialogs.Wpf/VistaFolderBrowserDialog.cs
+++ b/src/Ookii.Dialogs.Wpf/VistaFolderBrowserDialog.cs
@@ -250,22 +250,13 @@ namespace Ookii.Dialogs.Wpf
                 }
             }
 
-            dialog.SetOptions(NativeMethods.FOS.FOS_PICKFOLDERS | NativeMethods.FOS.FOS_FORCEFILESYSTEM | NativeMethods.FOS.FOS_FILEMUSTEXIST);
-
-            if( !string.IsNullOrEmpty(_selectedPath) )
+            // Set the default directory
+            if (Directory.Exists(_selectedPath))
             {
-                string parent = Path.GetDirectoryName(_selectedPath);
-                if( parent == null || !Directory.Exists(parent) )
-                {
-                    dialog.SetFileName(_selectedPath);
-                }
-                else
-                {
-                    string folder = Path.GetFileName(_selectedPath);
-                    dialog.SetFolder(NativeMethods.CreateItemFromParsingName(parent));
-                    dialog.SetFileName(folder);
-                }
+                dialog.SetFolder(NativeMethods.CreateItemFromParsingName(_selectedPath));
             }
+
+            dialog.SetOptions(NativeMethods.FOS.FOS_PICKFOLDERS | NativeMethods.FOS.FOS_FORCEFILESYSTEM | NativeMethods.FOS.FOS_FILEMUSTEXIST);
         }
 
         private void GetResult(Ookii.Dialogs.Wpf.Interop.IFileDialog dialog)


### PR DESCRIPTION
- Bug crash of VistaFolderBrowserDialog when using root directory path (same for VistaSaveFileDialog when directory is "C:\" and default file name is empty)
- Fixed issues: https://github.com/caioproiete/ookii-dialogs-wpf/issues/8 and https://github.com/caioproiete/ookii-dialogs-wpf/issues/9